### PR TITLE
Update Error Handling

### DIFF
--- a/Campmon.Dynamics.WorkflowActivities/SyncHandler.cs
+++ b/Campmon.Dynamics.WorkflowActivities/SyncHandler.cs
@@ -88,10 +88,15 @@ namespace Campmon.Dynamics.WorkflowActivities
                     false, // queueSubscriptionBasedAutoResponders
                     false); // restartSubscriptionBasedAutoResponders
                 }
-                catch(Exception ex)
+                catch (CreatesendException ex)
                 {
-                    trace.Trace("Error on subscriber import: " + ex.Message);
+                    trace.Trace("CreatesendException Error on subscriber import: " + ex.Error.Message);
+                    trace.Trace("Exception Error on subscriber import: " + ex.Message);
+
+                    syncData.BulkSyncErrors.Add(new BulkSyncError("import", ex.Error.Message, ""));
                     syncData.BulkSyncErrors.Add(new BulkSyncError("import", ex.Message, ""));
+
+                    trace.Trace("CreatesendException error occurred: Subscriber import ended.");
                 }
 
                 trace.Trace("Subscriber import ended.");


### PR DESCRIPTION
Update error handling to give a more descriptive error message from
createsendexception and fix object reference error when failure details
is called